### PR TITLE
Internet accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ chmod -R o=-x ~/Dropbox
 ## What it Does
 
 - Backs up all the preferences in `~/Library/Preferences` and `/Library/Preferences`
+- Backs up all 'Internet Accounts' databases in `~/Library/Accounts`
 - Backs up PowerManagement preferences
 - Backs up shared file lists (Finder Favorites in Sidebar) `~/Library/Application Support/com.apple.sharedfilelist`
 - Backups up dotfiles ($HOME/.* (e.g. .bash_profile))

--- a/app_store_preferences.py
+++ b/app_store_preferences.py
@@ -25,7 +25,7 @@ def restore():
 
 def build_file_list():
     source = get_app_store_preferences_dir()
-    command = 'find ' + source + '*/Data/Library/Preferences -type f -name "*.plisit"'
+    command = 'find ' + source + '*/Data/Library/Preferences -type f -name "*.plist"'
     result = execute_shell(command, is_shell=True)
     files = result.split('\n')
     return files

--- a/app_store_preferences.py
+++ b/app_store_preferences.py
@@ -25,7 +25,7 @@ def restore():
 
 def build_file_list():
     source = get_app_store_preferences_dir()
-    command = 'find ' + source + '*/Data/Library/Preferences -type f -name *.plist'
+    command = 'find ' + source + '*/Data/Library/Preferences -type f -name "*.plisit"'
     result = execute_shell(command, is_shell=True)
     files = result.split('\n')
     return files

--- a/config.py
+++ b/config.py
@@ -73,6 +73,17 @@ def get_user():
     return getpass.getuser()
 
 
+def get_internet_accounts_dir():
+    return path.join(get_home_dir(), 'Library/Accounts/')
+
+
+def get_internet_accounts_backup_dir():
+    return_val = path.join(
+        get_macprefs_dir(), 'Accounts/')
+    ensure_exists(return_val)
+    return return_val
+
+
 def get_user_launch_agents_dir():
     return path.join(get_home_dir(), 'Library/LaunchAgents/')
 

--- a/internet_accounts.py
+++ b/internet_accounts.py
@@ -1,0 +1,26 @@
+import logging as log
+from utils import copy_dir, ensure_dir_owned_by_user
+import config
+
+
+def backup():
+    log.info('Backing up internet accounts db files...')
+    backup_internet_accounts()
+
+
+def restore():
+    log.info('Restoring internet accounts db files...')
+    restore_internet_accounts()
+
+
+def backup_internet_accounts():
+    source = config.get_internet_accounts_dir()
+    dest = config.get_internet_accounts_backup_dir()
+    copy_dir(source, dest)
+
+
+def restore_internet_accounts():
+    source = config.get_internet_accounts_backup_dir()
+    dest = config.get_internet_accounts_dir()
+    copy_dir(source, dest, with_sudo=True)
+    ensure_dir_owned_by_user(dest, config.get_user())

--- a/macprefs
+++ b/macprefs
@@ -11,6 +11,7 @@ import system_preferences
 import ssh_files
 import startup_items
 import app_store_preferences
+import internet_accounts
 
 def backup():
     system_preferences.backup()
@@ -20,6 +21,7 @@ def backup():
     ssh_files.backup()
     preferences.backup()
     app_store_preferences.backup()
+    internet_accounts.backup()
     print('Backup Complete.')
 
 
@@ -31,6 +33,7 @@ def restore():
     ssh_files.restore()
     preferences.restore()
     app_store_preferences.restore()
+    internet_accounts.restore()
     print('Restore Complete.')
 
 

--- a/test_internet_accounts.py
+++ b/test_internet_accounts.py
@@ -1,0 +1,38 @@
+from mock import patch
+
+import internet_accounts
+import config
+
+@patch('internet_accounts.backup_internet_accounts')
+def test_backup(internet_accounts_mock):
+    internet_accounts.backup()
+    internet_accounts_mock.assert_called_once()
+
+
+@patch('internet_accounts.restore_internet_accounts')
+def test_restore(internet_accounts_mock):
+    internet_accounts.restore()
+    internet_accounts_mock.assert_called_once()
+
+
+@patch('internet_accounts.copy_dir')
+def test_backup_internet_accounts(copy_mock):
+    source = config.get_internet_accounts_dir()
+    dest = config.get_internet_accounts_backup_dir()
+    internet_accounts.backup_internet_accounts()
+    copy_mock.assert_called_with(
+        source, dest
+    )
+
+
+@patch('internet_accounts.ensure_dir_owned_by_user')
+@patch('internet_accounts.copy_dir')
+def test_restore_internet_accounts(copy_mock, owned_mock):
+    internet_accounts.restore_internet_accounts()
+    copy_mock.assert_called_with(
+        config.get_internet_accounts_backup_dir(),
+        config.get_internet_accounts_dir(), with_sudo=True
+    )
+    owned_mock.assert_called_with(
+        config.get_internet_accounts_dir(), config.get_user()
+    )

--- a/test_macprefs.py
+++ b/test_macprefs.py
@@ -53,7 +53,7 @@ def test_invoke_no_args(mock_stdout):
     except SystemExit as e:
         assert_correct_std_out(e, mock_stdout)
 
-
+@patch('internet_accounts.backup')
 @patch('app_store_preferences.backup')
 @patch('startup_items.backup')
 @patch('ssh_files.backup')
@@ -64,7 +64,7 @@ def test_invoke_no_args(mock_stdout):
 # pylint: disable-msg=too-many-arguments
 def test_backup(system_preferences_mock, preferences_mock,
                 shared_files_mock, dotfiles_mock,
-                ssh_mock, startup_mock, app_store_mock):
+                ssh_mock, startup_mock, app_store_mock,internet_accounts_mock):
     macprefs.backup()
     system_preferences_mock.assert_called_once()
     preferences_mock.assert_called_once()
@@ -73,8 +73,9 @@ def test_backup(system_preferences_mock, preferences_mock,
     ssh_mock.assert_called_once()
     startup_mock.assert_called_once()
     app_store_mock.assert_called_once()
+    internet_accounts_mock.assert_called_once()
 
-
+@patch('internet_accounts.restore')
 @patch('app_store_preferences.restore')
 @patch('startup_items.restore')
 @patch('ssh_files.restore')
@@ -85,7 +86,7 @@ def test_backup(system_preferences_mock, preferences_mock,
 # pylint: disable-msg=too-many-arguments
 def test_restore(system_preferences_mock, preferences_mock,
                  shared_files_mock, dotfiles_mock,
-                 ssh_mock, startup_mock, app_store_mock):
+                 ssh_mock, startup_mock, app_store_mock,internet_accounts_mock):
     macprefs.restore()
     system_preferences_mock.assert_called_once()
     preferences_mock.assert_called_once()
@@ -94,6 +95,7 @@ def test_restore(system_preferences_mock, preferences_mock,
     ssh_mock.assert_called_once()
     startup_mock.assert_called_once()
     app_store_mock.assert_called_once()
+    internet_accounts_mock.assert_called_once()
 
 
 def assert_correct_std_out(e, mock_stdout):


### PR DESCRIPTION
Add support for Internet Accounts database backup
will backup/restore the content of ~/Library/Accounts