### PR TITLE
Change python requirement from 3.6 to 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Running `defaults write` with the wrong case for the keys or domains also causes
 ## Requirements
 
 - Mac OS X greater than 10.9 (maybe older… didn't test)
-- Python 3.6
+- Python 2.x
 
 ## Installation
 


### PR DESCRIPTION
Per marcomc's comment here:
https://github.com/clintmod/macprefs/issues/9#issuecomment-932766969