### PR TITLE
CI: parallel test/lint/build/contrib jobs + brew package build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,13 @@ jobs:
   # fresh contributor actually follows.
   contrib-workflow:
     runs-on: macos-latest
+    # mise resolves github:clintmod/rite via the GitHub API; unauthenticated
+    # requests share the runner IP's 60/hr quota and 403 constantly. The
+    # other jobs get a token injected by mise-action; this one bootstraps
+    # bare, so pass the workflow token explicitly. (Locally, mise picks up
+    # your gh CLI auth instead.)
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,34 @@ jobs:
       - name: Test
         run: rite test
 
+  lint:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v2
+
       - name: Lint
         run: rite lint
+
+  # "Does it build": render the formula against a tarball of HEAD, brew
+  # install it, run the formula test block, then a real `macprefs backup`
+  # end-to-end on the runner.
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v2
+
+      - name: Build, install, and smoke test the brew package
+        run: rite build
 
   # Verifies the documented contributor workflow from a bare machine,
   # exactly as the README's "Getting started" section describes it:
   # curl-install mise -> mise install -> rite setup -> rite test lint.
-  # The `test` job above uses mise-action, which is faster but not the
-  # path a fresh contributor actually follows.
+  # The jobs above use mise-action, which is faster but not the path a
+  # fresh contributor actually follows.
   contrib-workflow:
     runs-on: macos-latest
     steps:

--- a/Ritefile.yml
+++ b/Ritefile.yml
@@ -48,6 +48,12 @@ tasks:
     cmds:
       - uv run pylint *.py
 
+  build:
+    desc: Build the brew package from committed HEAD, install, verify, uninstall
+    aliases: [b]
+    cmds:
+      - ./ci/scripts/brew-build-test.sh
+
   clean:
     desc: Remove generated files
     aliases: [c]

--- a/ci/scripts/brew-build-test.sh
+++ b/ci/scripts/brew-build-test.sh
@@ -25,11 +25,17 @@ sed -e "s|url \".*\"|url \"file://$TARBALL\"|" \
     -e "s|###sha256###|$SHA|" \
     macprefs.template.rb > "$TMP/macprefs.rb"
 
-brew install --formula "$TMP/macprefs.rb"
-trap 'brew uninstall --force macprefs >/dev/null 2>&1 || true; rm -rf "$TMP"' EXIT
+# Homebrew requires formulae to live in a tap; use a throwaway local one.
+TAP="macprefs-ci/local"
+brew untap -f "$TAP" >/dev/null 2>&1 || true
+brew tap-new --no-git "$TAP" >/dev/null
+trap 'brew uninstall --force macprefs >/dev/null 2>&1 || true; brew untap -f "$TAP" >/dev/null 2>&1 || true; rm -rf "$TMP"' EXIT
+cp "$TMP/macprefs.rb" "$(brew --repository "$TAP")/Formula/macprefs.rb"
+
+brew install "$TAP/macprefs"
 
 # Formula's own test block (runs `macprefs --help`).
-brew test "$TMP/macprefs.rb"
+brew test "$TAP/macprefs"
 
 INSTALLED_VERSION=$(macprefs --version)
 echo "installed: $INSTALLED_VERSION"

--- a/ci/scripts/brew-build-test.sh
+++ b/ci/scripts/brew-build-test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Build the brew package from the committed tree (git archive HEAD), render
+# the formula template against the local tarball, install it, verify the
+# installed CLI end-to-end with a real backup, then uninstall.
+#
+# Refuses to run if macprefs is already installed via brew (it would clobber
+# the real install) unless FORCE=1 is set.
+set -euo pipefail
+
+VERSION=$(python3 -c "import version; print(version.__version__.lstrip('v'))")
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+if brew list macprefs &>/dev/null && [ "${FORCE:-0}" != "1" ]; then
+    echo "macprefs is already installed via brew - refusing to clobber it." >&2
+    echo "Re-run with FORCE=1 to uninstall it and test anyway." >&2
+    exit 1
+fi
+
+TARBALL="$TMP/macprefs-$VERSION.tar.gz"
+git archive --prefix="macprefs-$VERSION/" -o "$TARBALL" HEAD
+SHA=$(shasum -a 256 "$TARBALL" | cut -d' ' -f1)
+
+sed -e "s|url \".*\"|url \"file://$TARBALL\"|" \
+    -e "s|###sha256###|$SHA|" \
+    macprefs.template.rb > "$TMP/macprefs.rb"
+
+brew install --formula "$TMP/macprefs.rb"
+trap 'brew uninstall --force macprefs >/dev/null 2>&1 || true; rm -rf "$TMP"' EXIT
+
+# Formula's own test block (runs `macprefs --help`).
+brew test "$TMP/macprefs.rb"
+
+INSTALLED_VERSION=$(macprefs --version)
+echo "installed: $INSTALLED_VERSION"
+echo "$INSTALLED_VERSION" | grep -q "$VERSION"
+
+# End-to-end: a real backup into a throwaway dir. Backup only reads system
+# state and writes to MACPREFS_BACKUP_DIR, so this is safe anywhere.
+MACPREFS_BACKUP_DIR="$TMP/backup" macprefs backup
+test -d "$TMP/backup/preferences"
+
+echo "brew package build + install + backup smoke test: OK"


### PR DESCRIPTION
Follow-up to #27 — these two commits landed just after it was merged.

## Changes

- **CI split into four parallel jobs**: `test`, `lint`, `build`, `contrib-workflow` — each on its own runner, so wall-clock is the slowest job instead of the sum.
- **New `build` job / `rite build` task** ("does it build"): renders `macprefs.template.rb` against a `git archive` tarball of HEAD, installs it through a throwaway local tap (Homebrew rejects out-of-tap formula files), runs the formula's test block, verifies `macprefs --version`, then runs a **real `macprefs backup`** end-to-end into a temp dir before uninstalling and untapping. The script refuses to run locally if macprefs is already brew-installed (FORCE=1 overrides).

## Verified

`rite build` run locally end-to-end: formula rendered, installed (1.0.27), `brew test` passed, real backup completed, clean uninstall/untap. Bonus: the live backup exercised the rsync-23 tolerance from #25 against the exact Microsoft Teams daemon plist from #14 — warned and continued as designed.

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
