### PR TITLE
config:check: ban config files that shadow pyproject.toml tool sections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        check: ["format:check", "lock:check", typecheck, bandit, deptry, audit]
+        check: ["format:check", "lock:check", "config:check", typecheck, bandit, deptry, audit]
     name: ${{ matrix.check }}
     runs-on: macos-latest
     steps:

--- a/Ritefile.yml
+++ b/Ritefile.yml
@@ -52,27 +52,27 @@ tasks:
     cmds:
       # src/macprefs is listed explicitly: it has no .py extension, so the
       # glob misses it, but pylint lints any file passed by name.
-      - uv run pylint src/*.py src/macprefs tests/*.py
+      - uv run pylint src/*.py src/macprefs tests/*.py ci/scripts/*.py
 
   lint:ruff:
     desc: Run ruff check
     deps: [setup]
     cmds:
-      - uv run ruff check src tests
+      - uv run ruff check src tests ci
 
   format:check:
     desc: Check formatting without changing files
     aliases: [fc]
     deps: [setup]
     cmds:
-      - uv run ruff format --check src tests
+      - uv run ruff format --check src tests ci
 
   typecheck:
     desc: Type-check with pyright (basic mode; untyped codebase)
     aliases: [tc]
     deps: [setup]
     cmds:
-      - uv run pyright src tests
+      - uv run pyright src tests ci
 
   bandit:
     desc: Security-lint the source with bandit
@@ -93,7 +93,7 @@ tasks:
 
   check:
     desc: Run every check (what CI runs)
-    deps: [test, lint, format:check, lock:check, typecheck, bandit, deptry, gitleaks, audit]
+    deps: [test, lint, format:check, lock:check, config:check, typecheck, bandit, deptry, gitleaks, audit]
 
   lint:shell:
     desc: Shellcheck the ci scripts
@@ -107,6 +107,13 @@ tasks:
       - actionlint
       - uv run zizmor .github/workflows
 
+  config:check:
+    desc: Fail if a config file shadows pyproject.toml tool sections
+    aliases: [cc]
+    deps: [setup]
+    cmds:
+      - uv run python ci/scripts/check-config-shadowing.py
+
   lock:check:
     desc: Verify uv.lock is in sync with pyproject.toml
     aliases: [lc]
@@ -118,8 +125,8 @@ tasks:
     aliases: [f]
     deps: [setup]
     cmds:
-      - uv run ruff check --fix src tests
-      - uv run ruff format src tests
+      - uv run ruff check --fix src tests ci
+      - uv run ruff format src tests ci
 
   audit:
     desc: Scan locked dependencies for known vulnerabilities

--- a/ci/scripts/check-config-shadowing.py
+++ b/ci/scripts/check-config-shadowing.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Fail if a config file shadows a [tool.*] section in pyproject.toml.
+
+Every tool configured in pyproject.toml also discovers standalone config
+files, and the standalone file wins -- mostly silently: uv.toml disables
+[tool.uv] with no warning, an empty pytest.ini shadows
+[tool.pytest.ini_options], and a ruff.toml in a subdirectory replaces
+(not extends) the root lint rules for that subtree. This check bans the
+whole discovery chain so pyproject.toml stays the single source of truth.
+
+Scans tracked and untracked-unignored files, so a stray local file fails
+`rite check` before it is ever committed.
+"""
+
+import subprocess
+import sys
+
+# basename -> (tool that reads it, what happens when it exists)
+FORBIDDEN = {
+    "uv.toml": ("uv", "read instead of [tool.uv], which is then ignored with no warning"),
+    "pytest.toml": ("pytest", "outranks [tool.pytest.ini_options]"),
+    ".pytest.toml": ("pytest", "outranks [tool.pytest.ini_options]"),
+    "pytest.ini": ("pytest", "outranks [tool.pytest.ini_options], even when empty"),
+    ".pytest.ini": ("pytest", "outranks [tool.pytest.ini_options], even when empty"),
+    "ruff.toml": ("ruff", "replaces, not extends, [tool.ruff] for its whole subtree"),
+    ".ruff.toml": ("ruff", "replaces, not extends, [tool.ruff] for its whole subtree"),
+    "pylintrc": ("pylint", "outranks [tool.pylint.*]"),
+    ".pylintrc": ("pylint", "outranks [tool.pylint.*]"),
+    "pylintrc.toml": ("pylint", "outranks [tool.pylint.*]"),
+    ".pylintrc.toml": ("pylint", "outranks [tool.pylint.*]"),
+    "pyrightconfig.json": ("pyright", "always beats [tool.pyright]"),
+    ".coveragerc": ("coverage", "outranks pyproject.toml; could weaken the coverage gate"),
+    ".gitleaks.toml": ("gitleaks", "auto-loaded; an [allowlist] would weaken the secret scan"),
+    "tox.ini": ("pytest/coverage", "its [pytest] and [coverage:*] sections shadow pyproject.toml; this repo does not use tox"),
+    "setup.cfg": ("pytest/coverage/pylint", "its tool sections shadow pyproject.toml; this repo does not use setuptools config"),
+}
+
+
+def repo_files() -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [path for path in result.stdout.split("\0") if path]
+
+
+def main() -> int:
+    offenders = []
+    for path in repo_files():
+        basename = path.rsplit("/", 1)[-1]
+        if basename in FORBIDDEN:
+            tool, why = FORBIDDEN[basename]
+            offenders.append(f"{path} ({tool}: {why})")
+    if offenders:
+        print("Config files must not shadow pyproject.toml [tool.*] sections:", file=sys.stderr)
+        for offender in offenders:
+            print(f"  {offender}", file=sys.stderr)
+        print(
+            "\nDelete the file(s) and keep the config in pyproject.toml. If a standalone"
+            "\nfile is genuinely needed, move that tool's config there deliberately and"
+            "\nremove its entry from ci/scripts/check-config-shadowing.py.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"config:check ok -- none of the {len(FORBIDDEN)} shadowing config filenames present")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,14 +83,14 @@ max-line-length = 130
 line-length = 130
 target-version = "py310"
 # The extensionless entrypoint needs to be named to be included.
-include = ["src/**/*.py", "tests/**/*.py", "src/macprefs"]
+include = ["src/**/*.py", "tests/**/*.py", "src/macprefs", "ci/**/*.py"]
 
 [tool.ruff.lint]
 # Default rules (pyflakes + core pycodestyle) plus import sorting.
 extend-select = ["I"]
 
 [tool.pyright]
-include = ["src", "tests"]
+include = ["src", "tests", "ci"]
 extraPaths = ["src"]
 # Untyped codebase: basic mode checks inference-visible errors only.
 typeCheckingMode = "basic"


### PR DESCRIPTION
Closes #39

## What

Adds a `config:check` gate (same idiom as `lock:check`) that fails if any config file exists that would shadow a `[tool.*]` section in `pyproject.toml`:

- **`ci/scripts/check-config-shadowing.py`** — manifest-driven: a table of 16 forbidden basenames (`uv.toml`, `pytest.ini`/`.pytest.ini`/`pytest.toml`/`.pytest.toml`, `ruff.toml`/`.ruff.toml`, the four pylintrc variants, `pyrightconfig.json`, `.coveragerc`, `.gitleaks.toml`, `tox.ini`, `setup.cfg`), each with the tool it belongs to and why it wins. Adding a future tool = adding a row.
- Scans `git ls-files --cached --others --exclude-standard`, so it catches **untracked** local strays before commit and **subdirectory** files (ruff's closest-config-wins means a `tests/ruff.toml` silently replaces all lint rules for `tests/`), while skipping `.venv`.
- New `config:check` rite task (alias `cc`), wired into `check:` and the CI `checks` matrix.
- Extends ruff/pylint/pyright/format coverage to `ci/` so the new script meets the same bar as `src` and `tests`.

## Why

All tool config here lives in `pyproject.toml`, but every tool's discovery chain prefers a standalone file — mostly silently (`uv.toml` disables `[tool.uv]` with **no warning**; an empty `pytest.ini` shadows `[tool.pytest.ini_options]`). Full shadow map and rejected alternatives (sp-repo-review, per-invocation `-c` pinning) in #39.

`tox.ini`/`setup.cfg` are banned unconditionally rather than section-conditionally: neither has any legitimate use in this repo (no tox, no setuptools config), and skipping the section-parsing keeps the script trivial. If that ever changes, the manifest row comes out deliberately.

## Testing

- `rite config:check` passes on a clean tree
- Planted `pytest.ini` (untracked, root) + `tests/ruff.toml` (subdirectory) → both reported, exit 1
- `rite lint:ruff`, `format:check`, `lint:pylint`, `typecheck`, `lint:actions`, `deptry` all pass with the new file and widened scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qn45YUDYJRtSm3zjgEdyha